### PR TITLE
Emit 'setPage' event on setPage

### DIFF
--- a/src/components/Paginatron.js
+++ b/src/components/Paginatron.js
@@ -79,6 +79,7 @@ export default {
       if (page > this.pages - 1 || page < 0) {
         throw new Error("Page is not valid");
       }
+      this.emit("setPage", page);
       this.page = page;
     },
     nextPage() {


### PR DESCRIPTION
When clicking a page button, there's no way to track which page is currently being displayed.
When clicking the prev & next buttons, the `current` prop is emitted, with this event we can do the same.
Then, in the page button slot we can apply css classes if the current page is the same.